### PR TITLE
fix(pmr-duration-atom): use [disabled]="condition" instead of [attr.disabled]

### DIFF
--- a/projects/ngx-pmr-duration-picker/src/lib/component/pmr-duration-atom/pmr-duration-atom.component.html
+++ b/projects/ngx-pmr-duration-picker/src/lib/component/pmr-duration-atom/pmr-duration-atom.component.html
@@ -5,7 +5,7 @@
       [class.filled]="value"
       type="number"
       [ngModel]="value || null"
-      [attr.disabled]="disabled"
+      [disabled]="disabled"
       (ngModelChange)="onValueChange($event)"
     />
   <label class="pmr-duration-atom-label">{{ label }}</label>


### PR DESCRIPTION
When [attr.disabled]="condition", the disabled attribute is always set to "true" or "false", which always causes the input to remain disabled as that attribute is present.

## Changes
- Replaced [attr.disabled] with [disabled] in atom template file.
